### PR TITLE
fix: compatibilidade com SDK MCP v1.26 no build

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,10 +1,10 @@
 {
   "servers": {
-    "products": {
+    "mercado-livre": {
       "type": "stdio",
       "command": "node",
       "args": [
-        "D:/www/newerton/mcp/mcp-mercado-livre/build/main.js"
+        "${workspaceFolder}/build/main.js"
       ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cheerio": "^1.0.0",
         "dayjs": "^1.11.13",
         "voca": "^1.4.1",
-        "zod": "^3.24.3"
+        "zod": "^4.4.3"
       },
       "bin": {
         "mcp-mercado-livre": "build/index.js"
@@ -848,15 +848,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
       "version": "3.25.1",
@@ -5940,9 +5931,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cheerio": "^1.0.0",
     "dayjs": "^1.11.13",
     "voca": "^1.4.1",
-    "zod": "^3.24.3"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.15.2",

--- a/src/interface/controllers/MercadoLivreToolsController.ts
+++ b/src/interface/controllers/MercadoLivreToolsController.ts
@@ -16,11 +16,13 @@ export class MercadoLivreToolsController {
   }
 
   private registerGetStockToolHandler(): void {
-    this.server.tool(
+    this.server.registerTool(
       'get-produtos',
-      'Buscar informações básicas de produtos',
       {
-        products: z.array(z.string()).describe('Array of product names'),
+        description: 'Buscar informações básicas de produtos',
+        inputSchema: {
+          products: z.array(z.string()).describe('Array of product names'),
+        },
       },
       async ({ products }) => {
         const infos = await this.service.getProducts(products);
@@ -28,7 +30,7 @@ export class MercadoLivreToolsController {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(infos, null, 2),
             },
           ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,14 +6,18 @@ import { MercadoLivreApiService } from './infrastructure/services/MercadoLivreAp
 import { MercadoLivreToolsController } from './interface/controllers/MercadoLivreToolsController.js';
 
 async function main() {
-  const server = new McpServer({
-    name: 'mercad-livre',
-    version: '1.0.0',
-    capabilities: {
-      resources: {},
-      tools: {},
+  const server = new McpServer(
+    {
+      name: 'mercado-livre',
+      version: '1.0.0',
     },
-  });
+    {
+      capabilities: {
+        resources: {},
+        tools: {},
+      },
+    },
+  );
 
   const apiService = new MercadoLivreApiService();
   const service = new MercadoLivreService(apiService);


### PR DESCRIPTION
## Resumo
Corrige falha de build do MCP com a versão atual do SDK.

## O que foi alterado
- Ajuste da inicialização do servidor para usar a assinatura correta de `McpServer`:
  - `new McpServer(serverInfo, options)`
- Atualização do registro de tool para API compatível com SDK atual (`registerTool`)
- Correção do nome do servidor:
  - `mercad-livre` -> `mercado-livre`

## Problema relacionado
Closes #33

## Validação
- npm run build ✅
- node build/main.js ✅ (inicia em stdio sem crash)
